### PR TITLE
Fix issues with celery retries

### DIFF
--- a/collective/celery/base_task.py
+++ b/collective/celery/base_task.py
@@ -96,8 +96,16 @@ class AfterCommitTask(Task):
         # if task is not None we are in a retry and site_path and
         # authorized_userid are already in kw
         if task is None:
-            kw['site_path'] = '/'.join(api.portal.get().getPhysicalPath())
-            kw['authorized_userid'] = api.user.get_current().getId()
+            try:
+                kw['site_path'] = '/'.join(api.portal.get().getPhysicalPath())
+            except api.exc.PloneApiError:
+                pass
+            try:
+                user = api.user.get_current()
+                if user is not None:
+                    kw['authorized_userid'] = user.getId()
+            except api.exc.PloneApiError:
+                pass
 
         without_transaction = options.pop('without_transaction', False)
 

--- a/collective/celery/base_task.py
+++ b/collective/celery/base_task.py
@@ -91,21 +91,18 @@ class AfterCommitTask(Task):
         # Let's see if this is a retry. An existing task means yes.
         # If it is one, we'll call _apply_async directly later on.
         task = getattr(self.request, 'task', None)
+        if task is not None and options.get('retries'):
+            self.request.retries = options['retries']
         task_id = options.get('task_id', None)
 
-        # if task is not None we are in a retry and site_path and
-        # authorized_userid are already in kw
-        if task is None:
-            try:
-                kw['site_path'] = '/'.join(api.portal.get().getPhysicalPath())
-            except api.exc.PloneApiError:
-                pass
-            try:
-                user = api.user.get_current()
-                if user is not None:
-                    kw['authorized_userid'] = user.getId()
-            except api.exc.PloneApiError:
-                pass
+        # Only look up site_path and authorized_userid if we don't already have
+        # them
+        if 'site_path' not in kw:
+            kw['site_path'] = '/'.join(api.portal.get().getPhysicalPath())
+        if 'authorized_userid' not in kw:
+            user = api.user.get_current()
+            if user is not None:
+                kw['authorized_userid'] = user.getId()
 
         without_transaction = options.pop('without_transaction', False)
 

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.1.5 (unreleased)
 ------------------
 
+- Fix ConflictError retries, and retries for tasks run using `celery call`.
+  [alecpm]
+
 - Allow tasks to be retried.
   [enfold_josh]
 


### PR DESCRIPTION
Celery retries were failing or not being run because of a few issues with the custom task implementation. This PR adds a `weakref` to the task function (when there's not already a reference available via `bind=True`) and uses that to ensure that the correct task is retried. It also includes small fixes to ensure the call to `apply_async` doesn't fail when run without the component architecture setup (since it will have been torn down after exception handling in some cases). This fixes both the long standing `ConflictError` retry issues described in #6, and issues encountered when trying to use retries via the `autoretry_for` property or explicit calls to `retry`.